### PR TITLE
Added Jinja2 extentions support and made Python 3 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ninja2
 ======
 
-jinja2 command line client
+jinja2 command line client v 0.2
 
 Dependencies
 ------------
@@ -14,13 +14,22 @@ Usage
 
 ```
 $ ninja2 -h
-ninja2 <-e | -j | -y> template.j2
-    -e render from environment
-    -j render from json file
-    -y render from yaml file
+usage: ninja2 [-h] [-V] (-e | -j | -y) [-l {i18n,do,loopcontrols}] template.j2
 
-  read a jinja2 template from file and values from stdin
-  either environment or json or yaml
+read a jinja2 template from file and values from stdin either environment or json or yaml
+
+positional arguments:
+  template.j2           File with Jinja2 template
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -V, --version         show program's version number and exit
+  -e, --env             render from environment
+  -j, --json            render from json file
+  -y, --yaml            render from yaml file
+  -l {i18n,do,loopcontrols}, --load {i18n,do,loopcontrols}
+                        load Jinja2 extentions, can be repeated
+
   (c) 2015 Sascha Spreitzer, MIT License
 ```
 
@@ -51,4 +60,13 @@ sspreitzer@s900x3c:~/git/ninja2⟫ cat test.yaml
 USER: yaml-user
 sspreitzer@s900x3c:~/git/ninja2⟫ ./ninja2 -y test.j2 < test.yaml
 yaml-user
+```
+
+Render from environment with all extentions loaded
+-----------------------
+```
+sspreitzer@s900x3c:~/git/ninja2⟫ cat test.j2 
+{{ USER }}
+sspreitzer@s900x3c:~/git/ninja2⟫ ./ninja2 -e -l do -l i18n -l loopcontrols test.j2 
+sspreitzer
 ```

--- a/ninja2
+++ b/ninja2
@@ -28,6 +28,7 @@ import sys
 import os
 import getopt
 import json
+import argparse
 
 try:
 	import yaml
@@ -35,42 +36,60 @@ try:
 except:
 	YAML=False
 
-from jinja2 import Template
+
+from jinja2 import Template,Environment
+
 
 def renderenv(t):
-	return Template(t).render(os.environ)
+	global base_env
+	return base_env.from_string(t).render(os.environ)
 
 def renderjson(t, j):
-	return Template(t).render(json.loads(j))
+	global base_env
+	return base_env.from_string(t).render(json.loads(j))
 
 def renderyaml(t, y):
-	return Template(t).render(yaml.load(y))
+	global base_env
+	return base_env.get_template(t).render(yaml.load(y))
+
+
 
 def main():
+	global base_env
+
+	# parsing command line
+	# parser = argparse.ArgumentParser(description='ninja2 <-e | -j | -y> template.j2')
+	parser = argparse.ArgumentParser( formatter_class=argparse.RawDescriptionHelpFormatter, 
+                               description='read a jinja2 template from file and values from stdin either environment or json or yaml',
+                               epilog='(c) 2015 Sascha Spreitzer, MIT License' )
+	parser.add_argument('-V','--version', action='version', version='%(prog)s 0.2')
+	agr_group = parser.add_mutually_exclusive_group(required=True)
+	agr_group.add_argument('-e','--env',help = "render from environment",action='store_true')
+	agr_group.add_argument('-j','--json',help = "render from json file",action='store_true')
+	agr_group.add_argument('-y','--yaml',help = "render from yaml file",action='store_true')
+	parser.add_argument('-l','--load',help = "load Jinja2 extentions, can be repeated",choices=['i18n','do','loopcontrols'],action='append')
+	parser.add_argument('input_file',metavar='template.j2',help = "File with Jinja2 template",type=argparse.FileType('r'))
+
+	args = parser.parse_args()
+
+	if args.load:
+		base_env = Environment(extensions=[ 'jinja2.ext.'+ element for element in args.load ])
+	else:
+		base_env = Environment()
+
 	try:
-		opts, args = getopt.getopt(sys.argv[1:], 'e:j:y:')
-		for opt, arg in opts:
-			if opt == '-e':
-				print renderenv(open(arg).read())
-			elif opt == '-j':
-				print renderjson(open(arg).read(), sys.stdin.read())
-			elif opt == '-y':
-				if YAML:
-					print renderyaml(open(arg).read(), sys.stdin.read())
-				else:
-					print "yaml not supported - install pyyaml"
-					sys.exit(3)
+		if args.env:
+			print(renderenv(args.input_file.read()))
+		elif args.json:
+			print(renderjson(args.input_file.read(), sys.stdin.read()))
+		elif args.yaml:
+			if YAML:
+				print(renderyaml(args.input_file.read(), sys.stdin.read()))
+			else:
+				print("yaml not supported - install pyyaml")
+				sys.exit(3)
 	except getopt.GetoptError:
-		print "ninja2 <-e | -j | -y> template.j2"
-		print "    -e render from environment"
-		print "    -j render from json file"
-		print "    -y render from yaml file"
-		print ""
-		print "  read a jinja2 template from file and values from stdin"
-		print "  either environment or json or yaml"
-		print "  (c) 2015 Sascha Spreitzer, MIT License"
 		sys.exit(2)
 
 if __name__=="__main__":
 	main()
-

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,21 @@ from setuptools import setup, find_packages
 
 setup(
       name = 'ninja2',
-      version = '0.1',
+      version = '0.2',
       description = 'Jinja2 command line client',
       url = 'https://github.com/sspreitzer/ninja2',
-      download_url = 'https://github.com/sspreitzer/ninja2/tarball/0.1',
+      download_url = 'https://github.com/sspreitzer/ninja2/tarball/0.2',
       author = 'Sascha Spreitzer',
       author_email = 'sascha@spreitzer.ch',
       license = 'MIT',
       classifiers = [
+                     'Environment :: Console',
+                     'License :: OSI Approved :: MIT License',
+                     'Operating System :: OS Independent",
                      'Development Status :: 4 - Beta',
                      'Programming Language :: Python :: 2',
+                     'Programming Language :: Python :: 3',
+                     'Topic :: Utilities",
                      ],
       keywords = 'ninja2 jinja2 python json yaml',
       install_requires = ['Jinja2'],


### PR DESCRIPTION
Small rework on your handy tool
1) Changed command line parsing method to "argparse"
2) Added config option to load Jinja 2 modules
3) It can be run by Python3. 

I did not edit setup.py.   It will need  version bump. 

